### PR TITLE
fix: adding feature store yamls for example and merging 0.25 index patch

### DIFF
--- a/examples/quickstart/feature_repo/feature_store.yaml
+++ b/examples/quickstart/feature_repo/feature_store.yaml
@@ -1,0 +1,11 @@
+project: feature_repo
+registry: data/registry.db
+provider: local
+online_store:
+    type: mysql
+    host: 127.0.0.1
+    port: 3306
+    database: feast
+    user: root
+    password: test
+entity_key_serialization_version: 2

--- a/examples/quickstart/feature_repo/sqlite_feature_store.yaml
+++ b/examples/quickstart/feature_repo/sqlite_feature_store.yaml
@@ -1,0 +1,7 @@
+project: feature_repo
+registry: data/registry.db
+provider: local
+online_store:
+    type: sqlite
+    path: data/online_store.db
+entity_key_serialization_version: 2

--- a/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
@@ -193,13 +193,13 @@ class MySQLOnlineStore(OnlineStore):
             
             index_exists = False
             for index in cur.fetchall():
-                if index[0] == f"{_table_id(project, table)}":
+                if index[2] == f"{_table_id(project, table)}":
                     index_exists = True
                     break
 
             if not index_exists:
                 cur.execute(
-                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX IF NOT EXISTS {_table_id(project, table)}_ek (entity_key);"
+                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX {_table_id(project, table)}_ek (entity_key);"
                 )
 
         for table in tables_to_delete:

--- a/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
@@ -193,13 +193,13 @@ class MySQLOnlineStore(OnlineStore):
             
             index_exists = False
             for index in cur.fetchall():
-                if index[2] == f"{_table_id(project, table)}_ek":
+                if index[0] == f"{_table_id(project, table)}":
                     index_exists = True
                     break
 
             if not index_exists:
                 cur.execute(
-                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX IF NOT EXISTS {_table_id(project, table)}_ek (entity_key);"
+                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX IF NOT EXISTS {_table_id(project, table)} (entity_key, feature_name);"
                 )
 
         for table in tables_to_delete:

--- a/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
@@ -199,7 +199,7 @@ class MySQLOnlineStore(OnlineStore):
 
             if not index_exists:
                 cur.execute(
-                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX IF NOT EXISTS {_table_id(project, table)} (entity_key, feature_name);"
+                    f"ALTER TABLE {_table_id(project, table)} ADD INDEX IF NOT EXISTS {_table_id(project, table)}_ek (entity_key);"
                 )
 
         for table in tables_to_delete:

--- a/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
@@ -193,7 +193,7 @@ class MySQLOnlineStore(OnlineStore):
             
             index_exists = False
             for index in cur.fetchall():
-                if index[2] == f"{_table_id(project, table)}":
+                if index[2] == f"{_table_id(project, table)}_ek":
                     index_exists = True
                     break
 


### PR DESCRIPTION
This PR patches a bug when running `feast apply` into the feature store. 

Without this indexing you'll get the following behavior:
```
feast apply
...
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IF NOT EXISTS feature_repo_driver_hourly_stats_stream_ek (entity_key)' at line 1")
```
This is because the `index` in the `for index in cur.fetchall():` line returns this tuple: `('<feature_view_table>', 0, 'PRIMARY', 1, 'entity_key', 'A', 0, None, None, '', 'BTREE', '', '')` where `<feature_view_table>` is the output of the `_table_id(project, table)` function. Notice how the current code extracts the [2] / third element, which in this case is `'PRIMARY'`. The current value is the first index.

Additionally, the `_ek` suffix is unnecessary in mysql because the sqlite implementation uses that convention purely for naming the operation to index the table.


With the new change simply:
```
[mysql-index-patch]% feast apply
/Users/francisco.arceo/github/feast/sdk/python/feast/feature_store.py:566: RuntimeWarning: On demand feature view is an experimental feature. This API is stable, but the functionality does not scale well for offline retrieval
  RuntimeWarning,
No changes to registry
Deploying infrastructure for driver_hourly_stats_stream
Deploying infrastructure for driver_hourly_stats
[mysql-index-patch]% CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
[mysql-index-patch]% feast materialize-incremental $CURRENT_TIME

Materializing 2 feature views to 2022-12-28 16:26:15-07:00 into the mysql online store.

driver_hourly_stats from 2022-12-28 11:06:58-07:00 to 2022-12-28 16:26:15-07:00:
0it [00:00, ?it/s]
driver_hourly_stats_stream from 2022-12-28 11:06:58-07:00 to 2022-12-28 16:26:15-07:00:
0it [00:00, ?it/s]
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
