### PR TITLE
Support Fragmented SQL Updates in Consistent Manner

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1487,6 +1487,33 @@ class FeatureStore:
         provider.ingest_df(feature_view, df)
 
     @log_exceptions_and_usage
+    def write_to_online_store_cooperative(
+            self,
+            feature_view_name: str,
+            df: pd.DataFrame,
+            old_df: Optional[pd.DataFrame],
+            allow_registry_cache: bool = True,
+    ):
+        """
+        Persists a dataframe to the online store.
+
+        Args:
+            feature_view_name: The feature view to which the dataframe corresponds.
+            df: The dataframe to be persisted.
+            allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
+        """
+        try:
+            feature_view = self.get_stream_feature_view(
+                feature_view_name, allow_registry_cache=allow_registry_cache
+            )
+        except FeatureViewNotFoundException:
+            feature_view = self.get_feature_view(
+                feature_view_name, allow_registry_cache=allow_registry_cache
+            )
+        provider = self._get_provider()
+        provider.ingest_dfs(feature_view, df, old_df)
+
+    @log_exceptions_and_usage
     def write_to_offline_store(
         self,
         feature_view_name: str,

--- a/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/contrib/mysql_online_store/mysql.py
@@ -56,6 +56,19 @@ class MySQLOnlineStore(OnlineStore):
             )
         return self._conn
 
+    def unpack_write_entity(self, entity: EntityKeyProto,
+                                  values: Dict[str, ValueProto],
+                                  ts: datetime,
+                                  created_ts: Optional[datetime]):
+        entity_key_bin = serialize_entity_key(
+            entity,
+            entity_key_serialization_version=2,
+        ).hex()
+        ts = _to_naive_utc(ts)
+        if created_ts is not None:
+            created_ts = _to_naive_utc(created_ts)
+        return entity_key_bin, values, ts, created_ts
+
     def online_write_batch(
         self,
         config: RepoConfig,
@@ -94,6 +107,76 @@ class MySQLOnlineStore(OnlineStore):
             conn.commit()
             if progress:
                 progress(1)
+
+    def online_write_batch_cooperative(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        old_data:  Optional[List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ]]
+    ) -> None:
+        if old_data and len(data) != len(old_data):
+            raise ValueError(f'More columns in new entry {len(data)} than old entry {len(old_data)}')
+
+        conn = self._get_conn(config)
+        cur = conn.cursor()
+
+        project = config.project
+        for i in range(len(data)):
+            entity_key, values, timestamp, created_ts = self.unpack_write_entity(**data[i])
+            if old_data:
+                old_entity_key, old_values, old_timestamp, old_created_ts = self.unpack_write_entity(**old_data[i])
+
+                # RB: this should be consistent between old and new
+                if entity_key != old_entity_key:
+                    raise ValueError(f'New entity key {entity_key} != old entity key {old_entity_key}')
+
+                if values.keys() != old_values.keys():
+                    raise ValueError(f'New features {values.keys()} != old features {old_values.keys()}')
+            try:
+                for feature_name, val in values.items():
+                    if old_data:
+                        old_val = old_values[feature_name]
+                        cur.execute(
+                            f"""
+                                    UPDATE {_table_id(project, table)}
+                                    SET value=%s, event_ts=%s, created_ts=%s
+                                    WHERE entity_key=%s and feature_name=%s and value=%s and event_ts=%s and created_ts=%s
+                                    """,
+                            (
+                                val.SerializeToString(),
+                                timestamp,
+                                created_ts,
+                                old_val.SerializeToString(),
+                                old_timestamp,
+                                old_created_ts
+                            ),
+                        )
+                    else:
+                        cur.execute(
+                            f"""
+                                    INSERT INTO {_table_id(project, table)}
+                                    (entity_key, feature_name, value, event_ts, created_ts)
+                                    values (%s, %s, %s, %s, %s)
+                                    """,
+                            (
+                                entity_key_bin,
+                                feature_name,
+                                val.SerializeToString(),
+                                timestamp,
+                                created_ts,
+                            ),
+                        )
+            except pymysql.IntegrityError as e:
+                if e.args[0] == ER.DUP_ENTRY:
+                    conn.rollback()
+                raise
+            # RB: commit everything
+            conn.commit()
 
     @staticmethod
     def write_to_table(

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -67,9 +67,9 @@ class OnlineStore(ABC):
                 Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
             ]],
             progress: Optional[Callable[[int], Any]],
-    ) -> None:
+    ) -> bool:
         # RB: optional to implement
-        return None
+        return False
 
     @abstractmethod
     def online_read(

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -56,6 +56,21 @@ class OnlineStore(ABC):
         """
         pass
 
+    def online_write_batch_cooperative(
+            self,
+            config: RepoConfig,
+            table: FeatureView,
+            data: List[
+                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+            ],
+            old_date: Optional[List[
+                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+            ]],
+            progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        # RB: optional to implement
+        return None
+
     @abstractmethod
     def online_read(
         self,

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -134,21 +134,7 @@ class Provider(ABC):
                 ]
             ],
             progress: Optional[Callable[[int], Any]],
-    ) -> None:
-        """
-        Writes a batch of feature rows to the online store.
-
-        If a tz-naive timestamp is passed to this method, it is assumed to be UTC.
-
-        Args:
-            config: The config for the current feature store.
-            table: Feature view to which these feature rows correspond.
-            data: A list of quadruplets containing feature data. Each quadruplet contains an entity
-                key, a dict containing feature values, an event timestamp for the row, and the created
-                timestamp for the row if it exists.
-            progress: Function to be called once a batch of rows is written to the online store, used
-                to show progress.
-        """
+    ) -> bool:
         pass
 
     def ingest_df(
@@ -163,6 +149,14 @@ class Provider(ABC):
             feature_view: The feature view to which the dataframe corresponds.
             df: The dataframe to be persisted.
         """
+        pass
+
+    def ingest_dfs(
+        self,
+        feature_store: FeatureView,
+        df: pd.DataFrame,
+        old_df: Optional[pd.DataFrame]
+    ) -> None:
         pass
 
     def ingest_df_to_offline_store(

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -120,6 +120,37 @@ class Provider(ABC):
         """
         pass
 
+    @abstractmethod
+    def online_write_batch_cooperative(
+            self,
+            config: RepoConfig,
+            table: FeatureView,
+            data: List[
+                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+            ],
+            old_data: Optional[
+                List[
+                    Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+                ]
+            ],
+            progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        """
+        Writes a batch of feature rows to the online store.
+
+        If a tz-naive timestamp is passed to this method, it is assumed to be UTC.
+
+        Args:
+            config: The config for the current feature store.
+            table: Feature view to which these feature rows correspond.
+            data: A list of quadruplets containing feature data. Each quadruplet contains an entity
+                key, a dict containing feature values, an event timestamp for the row, and the created
+                timestamp for the row if it exists.
+            progress: Function to be called once a batch of rows is written to the online store, used
+                to show progress.
+        """
+        pass
+
     def ingest_df(
         self,
         feature_view: FeatureView,


### PR DESCRIPTION
## The Issue 
Suppose you have two windows w_0 and w_1 — where w_1 the next window after w_0. Next, suppose you have events e_0 = (user_ari=abba, time=t_0) and e_1 = (user_ari=abba, time=t_1) where e_0 belongs to w_0 and e_1 belongs to w_1.
If the state collected in w_0 isn’t flushed to MYSQL before e_1 is received, then abba will aggregate its state on stale data. 

**Note**: this scenario is relatively uncommon in practice, but could be disastrous if not handled. 

## The Solution 
It suffices, for a given thread, to compare what the thread believes the old state to be versus that which is currently in feature view table. If the "old state" isn't in the table, the thread must aggregate again and try to write in a new transaction. 

## Testing 
Tomorrow....