### PR TITLE
Add Batching Support to Feast MySQL

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1498,31 +1498,6 @@ x
         provider = self._get_provider()
         provider.ingest_df(feature_view, df)
 
-    @log_exceptions_and_usage
-    def write_to_online_store_cooperative(
-            self,
-            feature_view_name: str,
-            df: pd.DataFrame,
-            old_df: Optional[pd.DataFrame],
-            allow_registry_cache: bool = True,
-    ):
-        """
-        Persists a dataframe to the online store.
-        Args:
-            feature_view_name: The feature view to which the dataframe corresponds.
-            df: The dataframe to be persisted.
-            allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
-        """
-        try:
-            feature_view = self.get_stream_feature_view(
-                feature_view_name, allow_registry_cache=allow_registry_cache
-            )
-        except FeatureViewNotFoundException:
-            feature_view = self.get_feature_view(
-                feature_view_name, allow_registry_cache=allow_registry_cache
-            )
-        provider = self._get_provider()
-        return provider.ingest_dfs(feature_view, df, old_df)
 
     @log_exceptions_and_usage
     def write_to_offline_store(

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -56,20 +56,6 @@ class OnlineStore(ABC):
         """
         pass
 
-    def online_write_batch_cooperative(
-            self,
-            config: RepoConfig,
-            table: FeatureView,
-            data: List[
-                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-            ],
-            old_date: Optional[List[
-                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-            ]],
-            progress: Optional[Callable[[int], Any]],
-    ) -> bool:
-        # RB: optional to implement
-        return False
 
     @abstractmethod
     def online_read(

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -160,24 +160,6 @@ class PassthroughProvider(Provider):
         if self.online_store:
             self.online_store.online_write_batch(config, table, data, progress)
 
-    def online_write_batch_cooperative(
-            self,
-            config: RepoConfig,
-            table: FeatureView,
-            data: List[
-                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-            ],
-            old_data: Optional[
-                List[
-                    Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-                ]
-            ]
-    ) -> bool:
-        set_usage_attribute("provider", self.__class__.__name__)
-        if self.online_store:
-            return self.online_store.online_write_batch_cooperative(config, table, data, old_data)
-        return False
-
     def offline_write_batch(
         self,
         config: RepoConfig,
@@ -234,29 +216,6 @@ class PassthroughProvider(Provider):
         self.online_write_batch(
             self.repo_config, feature_view, rows_to_write, progress=None
         )
-
-    def ingest_dfs(
-        self,
-        feature_view: FeatureView,
-        new_df: pd.DataFrame,
-        old_df: Optional[pd.DataFrame]
-    ) -> bool:
-        new_rows_to_write = self._unpack_df(feature_view, new_df)
-        if old_df:
-            old_rows_to_write = self._unpack_df(feature_view, old_df)
-        return self.online_write_batch_cooperative(
-            self.repo_config, feature_view, new_rows_to_write, old_rows_to_write if old_df else None
-        )
-
-    def ingest_df_to_offline_store(self, feature_view: FeatureView, table: pa.Table):
-        set_usage_attribute("provider", self.__class__.__name__)
-
-        if feature_view.batch_source.field_mapping is not None:
-            table = _run_pyarrow_field_mapping(
-                table, feature_view.batch_source.field_mapping
-            )
-
-        self.offline_write_batch(self.repo_config, feature_view, table, None)
 
     def materialize_single_feature_view(
         self,

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -120,22 +120,6 @@ class Provider(ABC):
         """
         pass
 
-    @abstractmethod
-    def online_write_batch_cooperative(
-            self,
-            config: RepoConfig,
-            table: FeatureView,
-            data: List[
-                Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-            ],
-            old_data: Optional[
-                List[
-                    Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-                ]
-            ],
-            progress: Optional[Callable[[int], Any]],
-    ) -> bool:
-        pass
 
     def ingest_df(
         self,
@@ -149,14 +133,6 @@ class Provider(ABC):
             feature_view: The feature view to which the dataframe corresponds.
             df: The dataframe to be persisted.
         """
-        pass
-
-    def ingest_dfs(
-            self,
-            feature_store: FeatureView,
-            df: pd.DataFrame,
-            old_df: Optional[pd.DataFrame]
-    ) -> bool:
         pass
 
     def ingest_df_to_offline_store(

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm33"
+VERSION = "0.28+affirm34"
 DESCRIPTION = "Python SDK for Feast"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
# Add Batching Support to Feast MySQL 
`write_to_online_store` for MySQL, which we personally wrote, is very slow. There's a couple of anti-patterns going on that are easy to resolve: 
1. Commits should happen less frequently. Currently we commit every time we process a row. 
2. `write_to_online_store` should perform batch inserts. This is obvious?
