### PR TITLE
Double Underscore Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm91"
+version = "0.28+affirm92"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1732,7 +1732,7 @@ x
         }
         if not full_feature_names:
             requested_result_row_names = {
-                name.rpartition("__")[-1] for name in requested_result_row_names
+                name.partition("__")[-1] for name in requested_result_row_names
             }
 
         feature_views = list(view for view, _ in grouped_refs)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm91"
+VERSION = "0.28+affirm92"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
# Allow Feature Names to Include Double Underscores 

`get_online_features` currently breaks because we partition on the last double underscore seen in a string to separate a feature name from its FeatureView: 
```
requested_result_row_names = {
    feat_ref.replace(":", "__") for feat_ref in _feature_refs
}
if not full_feature_names:
    requested_result_row_names = {
        name.rpartition("__")[-1] for name in requested_result_row_names
    }
```
Many backends, for instance Spark, support a small set of characters that can used in column names. Double underscore was likely chosen because all backends support underscore characters. However, Affirm makes liberal use of underscores in feature names, so this quirk should be fixed. 

https://github.com/feast-dev/feast/issues/2949 outlines this issue and provides some solutions. Because Spark only support underscores + alphanumeric characters, we should stick to this character set. If we wanted to choose another delimiter, it would need to be a unique combination of alphanumeric characters and underscores. 

This leaves two options:

1. Disallow double underscores in FeatureView names, 
2. Select a new delimiter. A logic choice is "___", a triple underscore. 

To prevent us from diverging from Feast `master` too much, we select the first option.  