### PR TITLE
fix: StreamFeatureView UI (transformation section)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm93"
+version = "0.28+affirm94"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm92"
+version = "0.28+affirm93"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm93"
+VERSION = "0.28+affirm94"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"

--- a/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
@@ -56,7 +56,7 @@ const StreamFeatureViewOverviewTab = ({
             </EuiTitle>
             <EuiHorizontalRule margin="xs" />
             <EuiCodeBlock language="py" fontSize="m" paddingSize="m">
-              {data.spec?.userDefinedFunction?.body}
+              {data.spec?.userDefinedFunction?.bodyText}
             </EuiCodeBlock>
           </EuiPanel>
         </EuiFlexItem>


### PR DESCRIPTION
**TLDR:**
`userDefinedFunction.body` was being accessed, instead of `userDefinedFunction.bodyText`

**Issue: ML-3377**
Stream Feature Views are not having their transformation string rendered ([here](https://jira.team.affirm.com/browse/ML-3377)). 

**Reason:**
The field being accessed ([body](https://github.com/Affirm/feast/blob/fe462858ab441ba86f3d1cd381a4595602d756bd/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx#L59)) corresponds to the the serialized python function. The field that should be getting accessed is [bodyText](https://github.com/Affirm/feast/blob/fe462858ab441ba86f3d1cd381a4595602d756bd/protos/feast/core/OnDemandFeatureView.proto#L88C5-L88C26), since it corresponds to the string representation of the udf. Notably, this is the same field being used by the [ODFV](https://github.com/Affirm/feast/blob/fe462858ab441ba86f3d1cd381a4595602d756bd/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx#L60).