### PR TITLE
Enable Option to Ignore UDFs when Listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm97"
+version = "0.28+affirm99"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -248,7 +248,7 @@ class BaseRegistry(ABC):
 
     @abstractmethod
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False, ignore_udfs: bool = False
     ) -> List[StreamFeatureView]:
         """
         Retrieve a list of stream feature views from the registry
@@ -256,7 +256,7 @@ class BaseRegistry(ABC):
         Args:
             project: Filter stream feature views based on project name
             allow_cache: Whether to allow returning stream feature views from a cached registry
-
+            ignore_udfs: If True, UDFs stored in the registry will not be loaded and SFV.udf will be set to `None`
         Returns:
             List of stream feature views
         """

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -94,7 +94,7 @@ class FeastObjectType(Enum):
                 project=project
             ),
             FeastObjectType.STREAM_FEATURE_VIEW: registry.list_stream_feature_views(
-                project=project,
+                project=project, ignore_udfs=True
             ),
             FeastObjectType.FEATURE_SERVICE: registry.list_feature_services(
                 project=project

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm97"
+VERSION = "0.28+affirm99"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
# Enable Option to Ignore UDFs when Listing 
## Issue 
Dill makes the assumption that functions are serialized and deserialized on the same env but different platforms. 
`dill.loads` can be unstable when called in a different env that in which the underlying object was serialized. 

We ran into this issue when computing registry diffs on `feast apply`. Namely, listing the SFVs currently loaded into the registry would attempt to call `dill.loads` on functions that no longer existed. This caused a lot of headaches. Hao made a quick fix by adding the option of disabling of udf loading for SFVs -- which is currently the default behavior when listing SFVs. Unfortunately, this causes some issues when attempting to use `list_stream_feature_views` outside of `feast apply`. 

