### PR TITLE
ML-3377 | Stream Feature View UI Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm99"
+version = "0.28+affirm100"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -248,7 +248,7 @@ class BaseRegistry(ABC):
 
     @abstractmethod
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False, feast_apply_operation: bool = False,
+        self, project: str, allow_cache: bool = False, ignore_udfs: bool = False,
     ) -> List[StreamFeatureView]:
         """
         Retrieve a list of stream feature views from the registry
@@ -256,7 +256,7 @@ class BaseRegistry(ABC):
         Args:
             project: Filter stream feature views based on project name
             allow_cache: Whether to allow returning stream feature views from a cached registry
-            feast_apply_operation: Whether a feast apply operation is being executed. Determines whether environment
+            ignore_udfs: Whether a feast apply operation is being executed. Determines whether environment
                 sensitive commands, such as dill.loads(), are skipped and 'None' is set as their results.
         Returns:
             List of stream feature views

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -248,7 +248,7 @@ class BaseRegistry(ABC):
 
     @abstractmethod
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False, feast_apply_operation: bool = False,
     ) -> List[StreamFeatureView]:
         """
         Retrieve a list of stream feature views from the registry
@@ -256,6 +256,8 @@ class BaseRegistry(ABC):
         Args:
             project: Filter stream feature views based on project name
             allow_cache: Whether to allow returning stream feature views from a cached registry
+            feast_apply_operation: Whether a feast apply operation is being executed. Determines whether environment
+                sensitive commands, such as dill.loads(), are skipped and 'None' is set as their results.
         Returns:
             List of stream feature views
         """

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -94,7 +94,7 @@ class FeastObjectType(Enum):
                 project=project
             ),
             FeastObjectType.STREAM_FEATURE_VIEW: registry.list_stream_feature_views(
-                project=project,
+                project=project, feast_apply_operation=True
             ),
             FeastObjectType.FEATURE_SERVICE: registry.list_feature_services(
                 project=project

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -94,7 +94,7 @@ class FeastObjectType(Enum):
                 project=project
             ),
             FeastObjectType.STREAM_FEATURE_VIEW: registry.list_stream_feature_views(
-                project=project, feast_apply_operation=True
+                project=project, ignore_udfs=True
             ),
             FeastObjectType.FEATURE_SERVICE: registry.list_feature_services(
                 project=project

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -992,7 +992,7 @@ class SqlRegistry(BaseRegistry):
                 for row in rows:
                     proto = proto_class.FromString(row[proto_field_name])
                     if python_class == StreamFeatureView:
-                        obj = python_class.from_proto(proto, True if kwargs["skip_udfs"] else False)
+                        obj = python_class.from_proto(proto, kwargs.get("skip_udfs", True))
                     else:
                         obj = python_class.from_proto(proto)
                     res.append(obj)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -254,7 +254,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False, feast_apply_operation: bool = False,
     ) -> List[StreamFeatureView]:
         if allow_cache:
             self._refresh_cached_registry_if_necessary()
@@ -267,6 +267,7 @@ class SqlRegistry(BaseRegistry):
             StreamFeatureViewProto,
             StreamFeatureView,
             "feature_view_proto",
+            skip_udfs=feast_apply_operation,
         )
 
     def apply_entity(self, entity: Entity, project: str, commit: bool = True):
@@ -991,7 +992,7 @@ class SqlRegistry(BaseRegistry):
                 for row in rows:
                     proto = proto_class.FromString(row[proto_field_name])
                     if python_class == StreamFeatureView:
-                        obj = python_class.from_proto(proto, True)
+                        obj = python_class.from_proto(proto, True if kwargs["skip_udfs"] else False)
                     else:
                         obj = python_class.from_proto(proto)
                     res.append(obj)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -254,7 +254,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False, feast_apply_operation: bool = False,
+        self, project: str, allow_cache: bool = False, ignore_udfs: bool = False,
     ) -> List[StreamFeatureView]:
         if allow_cache:
             self._refresh_cached_registry_if_necessary()
@@ -267,7 +267,7 @@ class SqlRegistry(BaseRegistry):
             StreamFeatureViewProto,
             StreamFeatureView,
             "feature_view_proto",
-            skip_udfs=feast_apply_operation,
+            skip_udfs=ignore_udfs,
         )
 
     def apply_entity(self, entity: Entity, project: str, commit: bool = True):
@@ -992,7 +992,7 @@ class SqlRegistry(BaseRegistry):
                 for row in rows:
                     proto = proto_class.FromString(row[proto_field_name])
                     if python_class == StreamFeatureView:
-                        obj = python_class.from_proto(proto, kwargs.get("skip_udfs", True))
+                        obj = python_class.from_proto(proto, kwargs.get("skip_udfs", False))
                     else:
                         obj = python_class.from_proto(proto)
                     res.append(obj)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm99"
+VERSION = "0.28+affirm100"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
**Problem**:
Transformations are not being rendered in feast: https://jira.team.affirm.com/browse/ML-3377

**TLDR**:
`StreamFeatureView.from_proto()` has a parameter that skips the deserialization of the `UserDefinedFunctionProto` within a `StreamFeatureViewProto`. This parameter was hard coded to True for stream feature views.

**Explanation**:
UDFs are stored as [dill](https://dill.readthedocs.io/en/latest/)-serialized bytes; dill is designed to load serialized values in the same environment (but not the same machine) they were serialized in. Consequently, loading a UDF from the registry during a new deploy can lead to unexpected behavior. Hence, the current approach of hard coding the parameter in `StreamFeatureView.from_proto()` to True. 

However, as previously stated, the only time that loading UDFs can be problematic is when the environment changes. This would only be a possibility during the execution of `feast apply`, so the hard coded value will be replaced with an additional parameter that determines whether the UDF should be deserialized (because `feast apply` wasn't ran) or shouldn't be deserialized (because `feast apply` was ran).