### PR TITLE
Lazily Initialize Proto Registry for SqlRegistry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm105"
+version = "0.28+affirm106"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm105"
+VERSION = "0.28+affirm106"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
Build cached registry, lazily. A subtle bug arises if we don't:
1. `feast apply` is called in a forked process.
2. A `FeatureStore` object is created, which also creates an `SqlRegistry` object.
3. `SqlRegistry` calls `self.proto()`, eventually this leads us to calling `dill.dumps` on an SFV or ODFV
            UDF with swapping the old udf with the new one. `dill.dumps` fails, sometimes silently.