### PR TITLE
Handle ODFV empty UDF case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm106"
+version = "0.28+affirm107"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm106"
+VERSION = "0.28+affirm107"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
Add `_empty_odfv_udf_fn` to handle `to_proto(.., skip_udf=True)` cases. Otherwise, ODFV construction will break. 