### PR TITLE
Add Apply Context to SqlRegistry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm110"
+version = "0.28+affirm111"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -40,6 +40,14 @@ class BaseRegistry(ABC):
     feature views, and data sources).
     """
 
+    @abstractmethod
+    def enter_apply_context(self):
+        pass
+
+    @abstractmethod
+    def exit_apply_context(self):
+        pass
+
     # Entity operations
     @abstractmethod
     def apply_entity(self, entity: Entity, project: str, commit: bool = True):
@@ -558,7 +566,7 @@ class BaseRegistry(ABC):
         ...
 
     @abstractmethod
-    def proto(self) -> RegistryProto:
+    def proto(self, ignore_udfs: bool = False) -> RegistryProto:
         """
         Retrieves a proto version of the registry.
 
@@ -571,7 +579,7 @@ class BaseRegistry(ABC):
         """Commits the state of the registry cache to the remote registry store."""
 
     @abstractmethod
-    def refresh(self, project: Optional[str] = None):
+    def refresh(self, project: Optional[str] = None, ignore_udfs: bool = False):
         """Refreshes the state of the registry cache by fetching the registry state from the remote registry store."""
 
     @staticmethod

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -566,7 +566,7 @@ class BaseRegistry(ABC):
         ...
 
     @abstractmethod
-    def proto(self, ignore_udfs: bool = False) -> RegistryProto:
+    def proto(self) -> RegistryProto:
         """
         Retrieves a proto version of the registry.
 
@@ -579,7 +579,7 @@ class BaseRegistry(ABC):
         """Commits the state of the registry cache to the remote registry store."""
 
     @abstractmethod
-    def refresh(self, project: Optional[str] = None, ignore_udfs: bool = False):
+    def refresh(self, project: Optional[str] = None):
         """Refreshes the state of the registry cache by fetching the registry state from the remote registry store."""
 
     @staticmethod

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -790,7 +790,7 @@ class Registry(BaseRegistry):
         """Tears down (removes) the registry."""
         self._registry_store.teardown()
 
-    def proto(self, ignore_udfs: bool = False) -> RegistryProto:
+    def proto(self) -> RegistryProto:
         return self.cached_registry_proto or RegistryProto()
 
     def _prepare_registry_for_changes(self, project: str):

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -176,7 +176,13 @@ class Registry(BaseRegistry):
     ) -> Optional[bytes]:
         pass
 
-    # The cached_registry_proto object is used for both reads and writes. In particular,
+    def enter_apply_context(self):
+        pass
+
+    def exit_apply_context(self):
+        pass
+
+        # The cached_registry_proto object is used for both reads and writes. In particular,
     # all write operations refresh the cache and modify it in memory; the write must
     # then be persisted to the underlying RegistryStore with a call to commit().
     cached_registry_proto: Optional[RegistryProto] = None
@@ -784,7 +790,7 @@ class Registry(BaseRegistry):
         """Tears down (removes) the registry."""
         self._registry_store.teardown()
 
-    def proto(self) -> RegistryProto:
+    def proto(self, ignore_udfs: bool = False) -> RegistryProto:
         return self.cached_registry_proto or RegistryProto()
 
     def _prepare_registry_for_changes(self, project: str):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -293,6 +293,7 @@ def apply_total_with_repo_instance(
         for data_source in data_sources:
             data_source.validate(store.config)
 
+    registry.enter_apply_context()
     registry_diff, infra_diff, new_infra = store.plan(repo)
 
     # For each object in the registry, determine whether it should be kept or deleted.
@@ -311,6 +312,7 @@ def apply_total_with_repo_instance(
     else:
         store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
         log_infra_changes(views_to_keep, views_to_delete)
+    registry.exit_apply_context()
 
 
 def log_infra_changes(

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -313,7 +313,7 @@ def apply_total_with_repo_instance(
         store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
         log_infra_changes(views_to_keep, views_to_delete)
     registry.exit_apply_context()
-
+    registry.refresh()
 
 def log_infra_changes(
     views_to_keep: Set[FeatureView], views_to_delete: Set[FeatureView]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm110"
+VERSION = "0.28+affirm111"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
# Add Apply Context to SqlRegistry 
An *apply context* is a field of a registry signifying that the registry is in a pre-applied state. In this state, udfs should not be loaded to prevent `dill.loads` failures. This is a stateful parameter, so careful consideration should be taken if we need to modify code in the repo_operations.py file.