### PR TITLE
Disable infer_features for ODFV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feast-affirm"
-version = "0.28+affirm114"
+version = "0.28+affirm115"
 description = "Feast - Affirm"
 authors = ["Francisco Arceo", "Ross Briden", "Maks Stachowiak"]
 readme = "README.md"

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -360,6 +360,7 @@ class OnDemandFeatureView(BaseFeatureView):
         Raises:
             RegistryInferenceFailure: The set of features could not be inferred.
         """
+        """
         rand_df_value: Dict[str, Any] = {
             "float": 1.0,
             "int": 1,
@@ -412,6 +413,8 @@ class OnDemandFeatureView(BaseFeatureView):
                 "OnDemandFeatureView",
                 f"Could not infer Features for the feature view '{self.name}'.",
             )
+        """
+        pass 
 
     @staticmethod
     def get_requested_odfvs(feature_refs, project, registry):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
     from distutils.core import setup
 
 NAME = "feast"
-VERSION = "0.28+affirm114"
+VERSION = "0.28+affirm115"
 DESCRIPTION = "Python SDK for Feast @ Affirm"
 URL = "https://github.com/feast-dev/feast"
 AUTHOR = "Feast"


### PR DESCRIPTION
ODFVs implements a function `infer_features`, which attempts to infer the output of your FV's UDF. This "meta" unittest sounds good, but quickly becomes a pain when we expect input values to have a certain structure (e.g. xml string, json string). In these cases, `infer_features` breaks, is loud, and can sometimes page people when deploying. 

We should add this back at some point, but for now the test is more of nuisance than an aid. 