### PR TITLE
Cache registry early.

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -170,7 +170,6 @@ class FeatureStore:
         registry_config = self.config.get_registry_config()
         if registry_config.registry_type == "sql":
             self._registry = SqlRegistry(registry_config, None, is_feast_apply=is_feast_apply)
-            self._registry.refresh()
         else:
             r = Registry(registry_config, repo_path=self.repo_path)
             r._initialize_registry(self.config.project)

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -169,12 +169,8 @@ class FeatureStore:
 
         registry_config = self.config.get_registry_config()
         if registry_config.registry_type == "sql":
-            self._registry = SqlRegistry(registry_config, None)
-
-            if is_feast_apply:
-                self._registry.enter_apply_context()
-                self._registry.refresh()
-                self._registry.exit_apply_context()
+            self._registry = SqlRegistry(registry_config, None, is_feast_apply=is_feast_apply)
+            self._registry.refresh()
         else:
             r = Registry(registry_config, repo_path=self.repo_path)
             r._initialize_registry(self.config.project)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -181,7 +181,7 @@ feast_metadata = Table(
 
 class SqlRegistry(BaseRegistry):
     def __init__(
-        self, registry_config: Optional[RegistryConfig], repo_path: Optional[Path], is_feast_apply: False,
+        self, registry_config: Optional[RegistryConfig], repo_path: Optional[Path], is_feast_apply: bool = False,
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
         self.engine: Engine = create_engine(registry_config.path, echo=False)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -195,6 +195,7 @@ class SqlRegistry(BaseRegistry):
             else 0
         )
         self._in_feast_apply_context = is_feast_apply
+        self.refresh()
 
     def enter_apply_context(self):
         self._in_feast_apply_context = True

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -181,7 +181,7 @@ feast_metadata = Table(
 
 class SqlRegistry(BaseRegistry):
     def __init__(
-        self, registry_config: Optional[RegistryConfig], repo_path: Optional[Path]
+        self, registry_config: Optional[RegistryConfig], repo_path: Optional[Path], is_feast_apply: False,
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
         self.engine: Engine = create_engine(registry_config.path, echo=False)
@@ -194,7 +194,7 @@ class SqlRegistry(BaseRegistry):
             if registry_config.cache_ttl_seconds is not None
             else 0
         )
-        self._in_feast_apply_context = False
+        self._in_feast_apply_context = is_feast_apply
 
     def enter_apply_context(self):
         self._in_feast_apply_context = True

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -219,8 +219,8 @@ def plan(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool)
     click.echo(infra_diff.to_string())
 
 
-def _prepare_registry_and_repo(repo_config, repo_path):
-    store = FeatureStore(config=repo_config)
+def _prepare_registry_and_repo(repo_config, repo_path, is_feast_apply=False):
+    store = FeatureStore(config=repo_config, is_feast_apply=is_feast_apply)
     project = store.project
     if not is_valid_name(project):
         print(
@@ -333,7 +333,7 @@ def log_infra_changes(
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
     os.chdir(repo_path)
-    project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
+    project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path, is_feast_apply=True)
     apply_total_with_repo_instance(
         store, project, registry, repo, skip_source_validation
     )


### PR DESCRIPTION
**Goal:**
Cache registry ASAP.

**Background:**
We’re having issues with timeout errors when retrieving from ml-ofs, often when a new pod is initialized. During serving (in `impl.py`), we use a cached version of the registry. This reduces latency significantly. However, to fix the UDF rendering issue, this was removed and caching was made a lazy operation within `sql.py`.

We don't want for caching to be a lazy operation anymore. This means that we need to cache the registry within the constructor of `SQLRegistry`. However, this cache needs to be aware of whether a `feast apply` is in progress, in order to avoid reintroducing the UDF issues.

**UDF Issue:**
More background on the relationship between `feast apply` and `udfs` can be read here: https://github.com/Affirm/feast/pull/72
